### PR TITLE
Adjust embladots position and hide toasts in users pages

### DIFF
--- a/client/frontend/src/app/calendario-e-inscripciones/page.jsx
+++ b/client/frontend/src/app/calendario-e-inscripciones/page.jsx
@@ -34,11 +34,14 @@ export default function CalendarAndRegistration() {
         eventDateStart,
         eventDateEnd
       ).catch((err) => {
-        toast({
-          variant: "destructive",
-          title: err.message,
-          className: "bg-secondRed text-white text-lg font-bold"
-        })
+        if (err.message !== 'Actualmente no hay ningún evento que cumpla con los parámetros seleccionados') {
+          toast({
+            variant: "destructive",
+            title: err.message,
+            className: "bg-secondRed text-white text-lg font-bold"
+          })          
+        }
+
       }).then((res) => {
         setFilteredEvents(res);
       });

--- a/client/frontend/src/app/page.jsx
+++ b/client/frontend/src/app/page.jsx
@@ -61,11 +61,13 @@ export default function Home() {
       eventDateEnd
     )
       .catch((err) => {
+        if (err.message !== 'Actualmente no hay ningún evento que cumpla con los parámetros seleccionados') {
         toast({
           variant: "destructive",
           title: err.message,
           className: "bg-secondRed text-white text-lg font-bold",
         });
+        }
       })
       .then((res) => {
         setFilteredEvents(res);

--- a/client/frontend/src/components/homepageSlider/css/embla.css
+++ b/client/frontend/src/components/homepageSlider/css/embla.css
@@ -111,7 +111,7 @@ html {--brand-primary: #24c347;
 .embla__dots {
   z-index: 1;
   position: absolute;
-  bottom: 2%;
+  bottom: 0.5%;
   left: 50%;
   transform: translateX(-50%); 
   display: flex;


### PR DESCRIPTION
Having toasts in user pages was causing redundancy because the information was already on the image and text that was rendered at the same time as the toast